### PR TITLE
Fix NameError: undefined 'force_complete' variable

### DIFF
--- a/src/normattiva2md/cli.py
+++ b/src/normattiva2md/cli.py
@@ -485,7 +485,7 @@ def main():
             # Add article reference to metadata if present (or if overridden by --completo)
             if article_ref:
                 metadata["article"] = article_ref
-            elif force_complete and parse_article_reference(input_source):
+            elif args.completo and parse_article_reference(input_source):
                 # Note that complete conversion was forced
                 metadata["article"] = parse_article_reference(
                     input_source


### PR DESCRIPTION
Fixes #16

The variable 'force_complete' was referenced on line 488 but was never defined. This caused a NameError when converting documents from normattiva.it URLs.

Changed 'force_complete' to 'args.completo' which is the correct argument flag for forcing complete document conversion.